### PR TITLE
Skip compilation on TruffleRuby

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,16 @@ jobs:
        run: apt-get update && apt-get install -y shellcheck
      - name: Shellcheck
        run: shellcheck libexec/*
+  compile-truffleruby:
+    name: Compile on truffleruby
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: truffleruby
+          bundler-cache: true
+      - run: bundle exec rake compile
   build-ruby:
     name: Build (ruby)
     outputs:

--- a/ext/libv8-node/extconf.rb
+++ b/ext/libv8-node/extconf.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 require 'mkmf'
+
+if RUBY_ENGINE == "truffleruby"
+  File.write("Makefile", dummy_makefile($srcdir).join(""))
+  return
+end
+
 create_makefile('libv8-node')
 
 require File.expand_path('location', __dir__)


### PR DESCRIPTION
* Running libv8 on GraalVM LLVM is unlikely to ever work, instead using Graal.js makes more sense. This is already the case in mini_racer. libv8-node is a necessary dependency of mini_racer on CRuby, so for TruffleRuby the extconf.rb simply creates a dummy Makefile.

As mentioned in https://github.com/rubyjs/mini_racer/pull/261#issuecomment-1374068232 this is useful if for some reason libv8-node is installed "from source" on TruffleRuby.
Which can happen either when using `gem github:` in a Gemfile like there, or potentially due to a Bundler issue for example https://github.com/rubygems/rubygems/issues/6165, or if the gem was installed on a platform where it's not available precompiled.