### PR TITLE
Disable use of Linux memory protection keys

### DIFF
--- a/libexec/extract-node
+++ b/libexec/extract-node
@@ -32,6 +32,7 @@ cd "${src}/node-v${version}"
 #patch -p1 < "${top}"/patch/gyp-libv8_monolith.patch
 #patch -p1 < "${top}"/patch/py2-icutrim.patch
 #patch -p1 < "${top}"/patch/py2-genv8constants.patch
+patch -p1 < "${top}"/patch/v8-disable-pkey.patch
 
 # TODO: the following still fails on py3 so the above one forcing py2 is needed
 # patch -p1 < ../../py3-genv8constants.patch

--- a/patch/v8-disable-pkey.patch
+++ b/patch/v8-disable-pkey.patch
@@ -1,0 +1,17 @@
+diff --git a/deps/v8/src/base/build_config.h b/deps/v8/src/base/build_config.h
+index 9ed4c8f102..dfca698506 100644
+--- a/deps/v8/src/base/build_config.h
++++ b/deps/v8/src/base/build_config.h
+@@ -35,11 +35,8 @@
+ #define V8_HAS_PTHREAD_JIT_WRITE_PROTECT 0
+ #endif
+ 
+-#if defined(V8_OS_LINUX) && defined(V8_HOST_ARCH_X64)
+-#define V8_HAS_PKU_JIT_WRITE_PROTECT 1
+-#else
++// disabled, see https://issues.chromium.org/issues/360909072
+ #define V8_HAS_PKU_JIT_WRITE_PROTECT 0
+-#endif
+ 
+ #if defined(V8_TARGET_ARCH_IA32) || defined(V8_TARGET_ARCH_X64)
+ #define V8_TARGET_ARCH_STORES_RETURN_ADDRESS_ON_STACK true


### PR DESCRIPTION
V8's default thread-isolated allocator has a bug on x64 Linux.

It uses memory protection keys (see `man 7 pkeys`) to write-protect JIT code memory but in a way that is currently incompatible with how we use threads.

Specifically, pkey permissions are inherited by child threads. Threads that are not descendants of the thread that allocates the pkey default to "no permissions" for that pkey.

Concretely, if thread A creates the v8::Platform (and the pkey) and write-protects memory, then later thread B tries to access that memory, it segfaults due to the lack of permissions.

The fix on V8's side is conceptually easy - call
pkey_set(PKEY_DISABLE_WRITE) before accessing the memory, to flip the permissions from "none" to "can read" - but until it's actually fixed, disable thread-isolation.

Fixes: https://github.com/rubyjs/mini_racer/issues/300
Refs: https://issues.chromium.org/issues/360909072