### PR TITLE
Disable madvise(MADV_DONTFORK)

### DIFF
--- a/libexec/extract-node
+++ b/libexec/extract-node
@@ -32,6 +32,7 @@ cd "${src}/node-v${version}"
 #patch -p1 < "${top}"/patch/gyp-libv8_monolith.patch
 #patch -p1 < "${top}"/patch/py2-icutrim.patch
 #patch -p1 < "${top}"/patch/py2-genv8constants.patch
+patch -p1 < "${top}"/patch/v8-disable-madv-dontfork.patch
 patch -p1 < "${top}"/patch/v8-disable-pkey.patch
 
 # TODO: the following still fails on py3 so the above one forcing py2 is needed

--- a/patch/v8-disable-madv-dontfork.patch
+++ b/patch/v8-disable-madv-dontfork.patch
@@ -1,0 +1,16 @@
+diff --git a/tools/v8_gypfiles/features.gypi b/tools/v8_gypfiles/features.gypi
+index 6e21dac6d7..bcf022fb28 100644
+--- a/tools/v8_gypfiles/features.gypi
++++ b/tools/v8_gypfiles/features.gypi
+@@ -73,7 +73,10 @@
+       }, {
+         'v8_enable_etw_stack_walking': 0,
+       }],
+-      ['OS=="linux"', {
++      # Disable madvise(MADV_DONTFORK), it's a great optimization for programs
++      # that fork & exec but not for programs that fork and keep running.
++      # It makes mini_racer's test/test_forking.rb test segfault.
++      ['False and OS=="linux"', {
+         # Sets -dV8_ENABLE_PRIVATE_MAPPING_FORK_OPTIMIZATION.
+         #
+         # This flag speeds up the performance of fork/execve on Linux systems for


### PR DESCRIPTION
Node.js uses it to speed up fork & exec (stops V8 heap pages from getting copied into the forked process; slow) but mini_racer also supports fork & continue.