### PR TITLE
Fix C++ tests, switch to C++17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,6 @@
 name: Build
 on:
+  - pull_request
   - push
 
 jobs:

--- a/test/gtest/CMakeLists.txt
+++ b/test/gtest/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.14)
 project(gtest)
 
-# GoogleTest requires at least C++14
-set(CMAKE_CXX_STANDARD 14)
+# V8 requires at least C++17
+set(CMAKE_CXX_STANDARD 17)
 
 include(FetchContent)
 FetchContent_Declare(

--- a/test/gtest/Framework.h
+++ b/test/gtest/Framework.h
@@ -16,7 +16,7 @@ struct Framework {
 		main();
 
 		v8::V8::Dispose();
-		v8::V8::ShutdownPlatform();
+		v8::V8::DisposePlatform();
 	}
 
 	inline static void runWithIsolateRaw(iso_main main) {


### PR DESCRIPTION
It was at C++14 but newer versions of V8 require C++17.