### PR TITLE
Disable incremental and concurrent marking

### DIFF
--- a/libexec/extract-node
+++ b/libexec/extract-node
@@ -35,6 +35,7 @@ cd "${src}/node-v${version}"
 patch -p1 < "${top}"/patch/v8-no-assert-trivially-copyable.patch
 patch -p1 < "${top}"/patch/v8-disable-madv-dontfork.patch
 patch -p1 < "${top}"/patch/v8-disable-pkey.patch
+patch -p1 < "${top}"/patch/v8-disable-marking.patch
 
 # TODO: the following still fails on py3 so the above one forcing py2 is needed
 # patch -p1 < ../../py3-genv8constants.patch

--- a/patch/v8-disable-marking.patch
+++ b/patch/v8-disable-marking.patch
@@ -1,0 +1,22 @@
+diff --git a/deps/v8/src/flags/flag-definitions.h b/deps/v8/src/flags/flag-definitions.h
+index 0d50ac1522..2854768562 100644
+--- a/deps/v8/src/flags/flag-definitions.h
++++ b/deps/v8/src/flags/flag-definitions.h
+@@ -1764,7 +1764,7 @@ DEFINE_BOOL(minor_ms_trace_fragmentation, false,
+ DEFINE_BOOL(trace_evacuation, false, "report evacuation statistics")
+ DEFINE_BOOL(trace_mutator_utilization, false,
+             "print mutator utilization, allocation speed, gc speed")
+-DEFINE_BOOL(incremental_marking, true, "use incremental marking")
++DEFINE_BOOL(incremental_marking, false, "use incremental marking")
+ DEFINE_BOOL(incremental_marking_bailout_when_ahead_of_schedule, true,
+             "bails out of incremental marking when ahead of schedule")
+ DEFINE_BOOL(incremental_marking_task, true, "use tasks for incremental marking")
+@@ -1794,7 +1794,7 @@ DEFINE_IMPLICATION(cppgc_young_generation, minor_ms)
+ DEFINE_NEG_IMPLICATION(cppgc_young_generation, reclaim_unmodified_wrappers)
+ DEFINE_BOOL(optimize_gc_for_battery, false, "optimize GC for battery")
+ #if defined(V8_ATOMIC_OBJECT_FIELD_WRITES)
+-DEFINE_BOOL(concurrent_marking, true, "use concurrent marking")
++DEFINE_BOOL(concurrent_marking, false, "use concurrent marking")
+ #else
+ // Concurrent marking cannot be used without atomic object field loads and
+ // stores.


### PR DESCRIPTION
Test if a segfault that shows up in production is the result of incremental marking at an inopportune time.